### PR TITLE
[Checkout Full] Remove format validation to phone number

### DIFF
--- a/packages/checkout-full/core/package.json
+++ b/packages/checkout-full/core/package.json
@@ -51,7 +51,6 @@
     "@stencil/core": "^2.6.0",
     "@stencil/react-output-target": "^0.1.0",
     "@stencil/vue-output-target": "^0.5.1",
-    "@types/google-libphonenumber": "^7.4.23",
     "@types/jest": "^26.0.23",
     "@types/puppeteer": "5.4.3",
     "jest": "26.6.3",
@@ -61,8 +60,6 @@
   "dependencies": {
     "@plug-checkout/core": "1.5.0",
     "axios": "^0.21.1",
-    "countries-and-timezones": "^3.3.0",
-    "google-libphonenumber": "^3.2.31",
     "inputmask": "^5.0.6",
     "payment": "2.3.0",
     "stdnum": "^1.3.8",

--- a/packages/checkout-full/core/src/components/plug-checkout-full/partials/plug-checkout-full-identification/plug-checkout-full-identification.schema.ts
+++ b/packages/checkout-full/core/src/components/plug-checkout-full/partials/plug-checkout-full-identification/plug-checkout-full-identification.schema.ts
@@ -1,16 +1,11 @@
 import * as Yup from 'yup'
-import ct from 'countries-and-timezones'
 import { isCPFOrCNPJ } from 'brazilian-values'
 import { validateTaxId } from '@plug-checkout/utils'
-
-import { PhoneNumberUtil } from 'google-libphonenumber'
 
 import { PlugCheckoutFullIdentificationFormValues } from './plug-checkout-full-identification.types'
 import { normalizeValidationErrors } from './plug-checkout-full-identification.utils'
 import { Locale } from '@plug-checkout/i18n/dist/utils'
 import { t } from '@plug-checkout/i18n'
-
-const phoneUtil = PhoneNumberUtil.getInstance()
 
 export const schema = (locale?: Locale) => {
   return Yup.object().shape({
@@ -20,33 +15,9 @@ export const schema = (locale?: Locale) => {
     email: Yup.string()
       .email(t('page.customer.fields.email.errorMessageInvalidFormat', locale))
       .required(t('page.customer.fields.email.errorMessageRequired', locale)),
-    phoneNumber: Yup.string()
-      .test(
-        'isValidPhoneNumber',
-        t('page.customer.fields.phoneNumber.errorMessageInvalidFormat', locale),
-        (value, context) => {
-          try {
-            const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-            const { countries } = ct.getTimezone(timezone)
-            const country = context.parent.country || countries[0] || 'BR'
-            const phoneNumber = phoneUtil.parseAndKeepRawInput(value, country)
-
-            if (!phoneUtil.isPossibleNumber(phoneNumber)) return false
-
-            const isValidPhone = phoneUtil.isValidNumberForRegion(
-              phoneNumber,
-              country,
-            )
-
-            return !!isValidPhone
-          } catch (err) {
-            return false
-          }
-        },
-      )
-      .required(
-        t('page.customer.fields.phoneNumber.errorMessageRequired', locale),
-      ),
+    phoneNumber: Yup.string().required(
+      t('page.customer.fields.phoneNumber.errorMessageRequired', locale),
+    ),
     documentType: Yup.string().when(['$currency'], {
       is: (currency: string) => currency !== 'BRL',
       then: Yup.string().test(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2433,11 +2433,6 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
   integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
 
-"@types/google-libphonenumber@^7.4.23":
-  version "7.4.23"
-  resolved "https://registry.yarnpkg.com/@types/google-libphonenumber/-/google-libphonenumber-7.4.23.tgz#c44c9125d45f042943694d605fd8d8d796cafc3b"
-  integrity sha512-C3ydakLTQa8HxtYf9ge4q6uT9krDX8smSIxmmW3oACFi5g5vv6T068PRExF7UyWbWpuYiDG8Nm24q2X5XhcZWw==
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -4142,11 +4137,6 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
-
-countries-and-timezones@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/countries-and-timezones/-/countries-and-timezones-3.3.0.tgz#c2a0c319cf1c6240bda9d69edcbd2d6861a091e6"
-  integrity sha512-HkuEKmiHSAOoRW6FAQsCywd6XI6V0g7a4EfQXc99c7bh4vnCAhnoZ1jHEV0QliJumbFX8lFbCX2nu5d8eUiEJw==
 
 cross-spawn@^5.1.0:
   version "5.1.0"
@@ -5927,11 +5917,6 @@ good-listener@^1.2.2:
   integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
   dependencies:
     delegate "^3.1.2"
-
-google-libphonenumber@^3.2.31:
-  version "3.2.31"
-  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.31.tgz#d2c4d4c8d7385be70b515086e4d28dd20da50600"
-  integrity sha512-l3bzAkfN4ITICKvuqEiY7JN06RxDAviOoKMtD2KfGYjGK3btPO8Xav7k0fgmf1Ud/pEm523yBh1/s/xDtKEvnw==
 
 got@^9.6.0:
   version "9.6.0"


### PR DESCRIPTION
## Motivation

Removed the format validation of the phone, because has a bug in this validation. In the next step, we will improve the validation experience.

## Proposed solution

Remove deps and validation schema to the `phoneNumber` field. Leaving only the `required` validation.

## Observations

No observations
